### PR TITLE
Fix signing hash of batch and shutter txs

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -326,6 +326,7 @@ func (s eip2930Signer) Hash(tx *Transaction) common.Hash {
 			[]interface{}{
 				s.chainId,
 				tx.BatchIndex(),
+				tx.L1BlockNumber(),
 				tx.Nonce(),
 				tx.GasTipCap(),
 				tx.GasFeeCap(),
@@ -338,7 +339,6 @@ func (s eip2930Signer) Hash(tx *Transaction) common.Hash {
 			[]interface{}{
 				s.chainId,
 				tx.BatchIndex(),
-				tx.DecryptionKey(),
 				tx.L1BlockNumber(),
 				tx.Timestamp(),
 				tx.Transactions(),


### PR DESCRIPTION
For Shutter txs, the signing hash excluded the L1BlockNumber field. This
was missed when we added the field to the transaction type.

For Batch txs, the signing hash included the decryption key. This makes
it impossible for the collator to commit to a batch which has to be done
before the decryption key is generated.