### PR TITLE
Fix missing signature field instantiation on copy

### DIFF
--- a/core/types/batch_tx.go
+++ b/core/types/batch_tx.go
@@ -28,6 +28,9 @@ func (tx *BatchTx) copy() TxData {
 		BatchIndex:    tx.BatchIndex,
 		L1BlockNumber: tx.L1BlockNumber,
 		Timestamp:     new(big.Int),
+		V:             new(big.Int),
+		R:             new(big.Int),
+		S:             new(big.Int),
 	}
 	if tx.ChainID != nil {
 		cpy.ChainID.Set(tx.ChainID)


### PR DESCRIPTION
When copying a signed BatchTx setting the V,R,S field
values on the copy would cause a nil-pointer de-reference
due to uninitialized fields.
It is unintuitive that the copy would have V,R,S null-value
big.Ints set after it has been copied when no signature values were
present before (nil pointer).
This however is how the other  transaction types are doing it as well,
and the copy method is always used before including the TxData
implementing structs in the Transaction struct, thus ensuring
a fully initialized object.