### PR TITLE
Add byte-encoding for DecryptedPayload

### DIFF
--- a/core/types/decrypted_payload.go
+++ b/core/types/decrypted_payload.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type DecryptedPayload struct {
@@ -30,4 +31,14 @@ func (p *DecryptedPayload) AsMessage(tx *Transaction, signer Signer) (Message, e
 		nil,           // access list
 		false,         // is fake
 	), nil
+}
+
+func (p *DecryptedPayload) Encode() ([]byte, error) {
+	return rlp.EncodeToBytes(*p)
+}
+
+func DecodeDecryptedPayload(b []byte) (*DecryptedPayload, error) {
+	p := &DecryptedPayload{}
+	err := rlp.DecodeBytes(b, p)
+	return p, err
 }


### PR DESCRIPTION
This PR adds convenience methods for rlp-encoding the decrypted payload included in `ShutterTx` transaction types.